### PR TITLE
fix: Use newest sdkmanager

### DIFF
--- a/android.go
+++ b/android.go
@@ -29,7 +29,7 @@ func ensureAndroidSdkSetup() error {
 		return err
 	}
 
-	sdkManagerPath := path.Join(androidHome, "tools/bin/sdkmanager")
+	sdkManagerPath := path.Join(androidHome, "cmdline-tools/cmdline-tools/bin/sdkmanager")
 
 	if !isCurrentSdkToolsUpToDate {
 		log.Infof("Current Android SDK version: %s is lower than 26. Updating...", currentSdkToolsVersion)


### PR DESCRIPTION
Use `cmdline-tools/bin/sdkmanager` which supports JDK 11. The old `tools/bin/sdkmanager` requires JDK 1.8, which isn't working on `compileSdkVersion 30`+.

Note cmdline-tools path is verified when connecting to a failing VM instance:

```
vm-osx-xcode-12:~ vagrant$ echo $PATH
/Users/vagrant/.jenv/shims:/Users/vagrant/.rbenv/shims:/usr/local/bin:/usr/local/sbin:~/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/vagrant/go/bin:/Users/vagrant/.pub-cache/bin:/Users/vagrant/fvm/default/bin:/Users/vagrant/bitrise/tools/cmd-bridge/bin/osx:/usr/local/share/android-sdk/ndk-bundle:/usr/local/share/android-sdk/platform-tools:/usr/local/share/android-sdk/cmdline-tools/cmdline-tools/bin:/Users/vagrant/.jenv/bin
```